### PR TITLE
Introduced issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,54 @@
+---
+name: 🐞 Bug
+about: Use this option to report bug in the application.
+title: ""
+labels: bug
+---
+
+## Summary
+_Please provide a summary of the problem you've encountered_
+
+<br>
+
+## Steps to Reproduce
+_Please provide reproduction steps as detailed as possible as non-reproducible issues may be closed as not actionable._
+1. …
+2. …
+3. …
+
+<br>
+
+## Expected Behaviour
+_What did you expect to happen?_ 
+
+<br>
+
+## Actual Behaviour
+_What actually happened?_ 
+
+<br>
+
+## Log Output
+```bash
+_Please add any relevant log output (i.e from error logs, console logs)_ 
+```
+
+<br>
+
+## System Information
+#### Operating System, incl. Version
+_i.e. MacOS 12.0.0_
+
+#### Browser, incl. Version: 
+_i.e. Chrome, Version 97.0.4692.99_
+
+<br>
+
+## Additional Context
+_If applicable, please add screenshots and/or screen recordings_
+
+
+<br>
+
+## Jira Ticket
+_Please insert the link to the respective JIRA ticket here._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🙋 Ask a question
+    url: https://learntap.slack.com/archives/GJ1HV2YM9
+    about: Ask questions and discuss with engineers on Slack

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,46 @@
+---
+name: 🚧 Feature
+about: Use this option for features and stories.
+title: ""
+labels: enhancement
+---
+
+## Summary
+_Please provide a summary of the feature that is to be implemented._
+
+<br>
+
+#### Why are we doing this?
+_..._
+
+#### What is the expected outcome?
+_..._
+
+<br>
+
+## Designs
+_If applicable, please insert a link to Figma here._
+
+<br>
+
+## Acceptance Criteria
+_Please outline the acceptance criteria in form of a checkbox list below._
+
+- [ ] …
+- [ ] …
+- [ ] …
+
+<br>
+
+## Technical Implementation
+_Engineering: if applicable, please include technical implementation details._
+
+<br>
+
+## Testing instructions
+_Engineering: please include detailed testing instructions for QA._
+
+<br>
+
+## Jira Ticket
+_Please insert the link to the respective JIRA ticket here._

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -16,6 +16,11 @@ _..._
 #### What is the expected outcome?
 _..._
 
+### What other issues does this depend on?
+- #(issue)
+- #(issue)
+- #(issue)
+
 <br>
 
 ## Designs
@@ -44,3 +49,4 @@ _Engineering: please include detailed testing instructions for QA._
 
 ## Jira Ticket
 _Please insert the link to the respective JIRA ticket here._
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,4 +22,4 @@ _If applicable, please upload a screenshot or screen recording of the applicatio
 
 <br>
 
-Fixes #(issue)
+Resolves #(issue)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Description
+_Please include a summary of the change and which issue is fixed or feature is implemented. Please also include relevant
+motivation and context, as well as list any dependencies that are required for this change._
+
+<br>
+
+## Additional Context
+_If applicable, please upload a screenshot or screen recording of the application's frontend showing implemented changes._
+
+<br>
+
+## Checklist
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have updated the documentation (incl. Swagger API docs)
+- [ ] I have reviewed all CodeClimate reviews and ajdusted my code accordingly
+- [ ] I have added tests and verified that my changes don't reduce the total code coverage score
+- [ ] I have written the PR title in the past tense (i.e. `Implemented xyz…`) 
+- [ ] I have tagged this PR with one of the required tags: `enhancement`, `bug`, `documentation` or `dependencies`
+- [ ] I have added detailed QA instructions to the ticket on both GitHub and Jira
+- [ ] I have referenced the corresponding GitHub issues at the bottom of this PR
+
+<br>
+
+Fixes #(issue)


### PR DESCRIPTION
This PR introduces issue and pull request templates shared across all repositories created in the Noggin Learning organisation, leveraging a GitHub feature known as [default community health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

Whilst these templates will be automatically made available in all repositories of this organisation, individual repositories still can override those by introducing their own templates. This should of course only be done if strictly necessary. 

<br>

### Issue Templates
Two issues templates have been created to cover both bug reports and feature requests. To make the reviewing process easier, I've created a temporary test repository where you can take those out for a spin: [noggin-learning/template-test/issues/new/choose](https://github.com/noggin-learning/template-test/issues/new/choose )

GitHub fairly recently introduced a new template format that leverages a rather nice [form schema syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema), making issue templates even more intuitive. Unfortunately, this feature is currently only available to public repositories. I have requested beta access but in the meantime, we're stuck with the standard format.

<img width="1243" alt="Screenshot 2022-02-03 at 17 03 47" src="https://user-images.githubusercontent.com/7336071/152380307-24483d51-634f-4354-b573-737c1776c395.png">

<br>

### PR Template
Same as with the PR template, you can take a look at a demo PR I setup on the test repository: https://github.com/noggin-learning/template-test/pull/2

<img width="915" alt="Screenshot 2022-02-03 at 17 03 30" src="https://user-images.githubusercontent.com/7336071/152380351-6158d09d-68c8-40f0-9908-67fbd88d327b.png">

<br>

resolves #1 
resolves #2